### PR TITLE
Grab settings

### DIFF
--- a/AlphaESS.postman_collection.json
+++ b/AlphaESS.postman_collection.json
@@ -1,0 +1,547 @@
+{
+	"info": {
+		"_postman_id": "3c1cacb5-d8f8-489a-909c-2872780bfa59",
+		"name": "AlphaESS",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23152579"
+	},
+	"item": [
+		{
+			"name": "Account",
+			"item": [
+				{
+					"name": "Login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"pm.globals.set(\"BearerToken\", jsonData.data.AccessToken);",
+									"",
+									"// Set current date for statistics",
+									"var moment = require('moment');",
+									"pm.globals.set('CurrentDate', moment().format((\"YYYY-MM-DD\")));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"username\": \"{{Username}}\",\r\n    \"password\": \"{{Password}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Account/Login",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"Login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetUserInfo",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{BaseUrl}}/Account/GetUserInfo",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"GetUserInfo"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetCustomMenuESSList",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"pm.globals.set(\"SysSn\", jsonData.data[0].sys_sn);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BaseUrl}}/Account/GetCustomMenuESSList",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"GetCustomMenuESSList"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetCustomUseESSList",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"var system = _.find(jsonData.data, {\"sys_sn\": pm.variables.get(\"SysSn\")})",
+									"pm.globals.set(\"SystemId\", system.system_id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BaseUrl}}/Account/GetCustomUseESSList",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"GetCustomUseESSList"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetCustomUseESSSetting",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"pm.globals.set(\"Settings\", JSON.stringify(jsonData.data));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BaseUrl}}/Account/GetCustomUseESSSetting?system_id={{SystemId}}",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"GetCustomUseESSSetting"
+							],
+							"query": [
+								{
+									"key": "system_id",
+									"value": "{{SystemId}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CustomUseESSSetting",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{{Settings}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Account/CustomUseESSSetting",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Account",
+								"CustomUseESSSetting"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "ESS",
+			"item": [
+				{
+					"name": "SticsSummeryDataForCustomer",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sn\": \"{{SysSn}}\",\r\n    \"tday\": \"{{CurrentDate}}\",\r\n    \"showLoading\": true\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/ESS/SticsSummeryDataForCustomer",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"ESS",
+								"SticsSummeryDataForCustomer"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetLastPowerDataBySN",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sys_sn\": \"{{SysSn}}\",\r\n    \"noLoading\": true\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/ESS/GetLastPowerDataBySN",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"ESS",
+								"GetLastPowerDataBySN"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Power",
+			"item": [
+				{
+					"name": "SticsByPeriod",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"beginDay\": \"{{CurrentDate}}\",\r\n    \"endDay\": \"{{CurrentDate}}\",\r\n    \"tday\": \"{{CurrentDate}}\",\r\n    \"isOEM\": 0,\r\n    \"SN\": \"{{SysSn}}\",\r\n    \"userId\": \"\",\r\n    \"noLoading\": true\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Power/SticsByPeriod",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Power",
+								"SticsByPeriod"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "SticsByDay",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sn\": \"{{SysSn}}\",\r\n    \"userId\": \"\",\r\n    \"szDay\": \"{{CurrentDate}}\",\r\n    \"isOEM\": 0,\r\n    \"sDate\": \"{{CurrentDate}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Power/SticsByDay",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Power",
+								"SticsByDay"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PredictivePower",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sDate\": \"{{CurrentDate}}\",\r\n    \"sTime\": \"12:00\",\r\n    \"lat\": \"\",\r\n    \"lon\": \"\",\r\n    \"panelNum\": 1,\r\n    \"pv\": 0.131,\r\n    \"isToday\": true,\r\n    \"sn\": \"{{SysSn}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Power/PredictivePower",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Power",
+								"PredictivePower"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Income",
+			"item": [
+				{
+					"name": "PayoffTotalResult",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"totalIncome\": \"\",\r\n    \"inputCost\": \"\",\r\n    \"sn\": \"{{SysSn}}\",\r\n    \"userId\": \"\",\r\n    \"isOEM\": 0,\r\n    \"statisticBy\": \"month\",\r\n    \"sDate\": \"{{CurrentDate}}\",\r\n    \"tDate\": \"{{CurrentDate}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Income/PayoffTotalResult",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Income",
+								"PayoffTotalResult"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PayoffStatistic",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"totalIncome\": \"\",\r\n    \"inputCost\": \"\",\r\n    \"sn\": \"{{SysSn}}\",\r\n    \"userId\": \"\",\r\n    \"isOEM\": 0,\r\n    \"statisticBy\": \"month\",\r\n    \"sDate\": \"{{CurrentDate}}\",\r\n    \"tDate\": \"{{CurrentDate}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BaseUrl}}/Income/PayoffStatistic",
+							"host": [
+								"{{BaseUrl}}"
+							],
+							"path": [
+								"Income",
+								"PayoffStatistic"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/AlphaESS.postman_globals.json
+++ b/AlphaESS.postman_globals.json
@@ -1,0 +1,57 @@
+{
+	"id": "d045876e-a70b-4b54-89b8-d779711d28e2",
+	"values": [
+		{
+			"key": "BaseUrl",
+			"value": "https://cloud.alphaess.com/api",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "Username",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "Password",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "BearerToken",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "SysSn",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "SystemId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CurrentDate",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "Settings",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"name": "Globals",
+	"_postman_variable_scope": "globals",
+	"_postman_exported_at": "2022-09-05T21:39:02.200Z",
+	"_postman_exported_using": "Postman/9.30.3"
+}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ Currently this package uses an API that I reverse engineered the API from the Al
 
 # Methods
 
-There are two public methods in this module
+There are four public methods in this module
 
-authenticate(username, password) - attempts to authenticate to the ALpha ESS API with a username and password combination, returns True or False depending on sucessful authentication or not
+authenticate(username, password) - attempts to authenticate to the ALpha ESS API with a username and password combination, returns True or False depending on successful authentication or not
 
-getdata() - having succesfully authenticated attempts to get statistical energy data on all registered Alpha ESS systems - will return None if there are issues retrieving data from the Alpha ESS API.
+getdata() - having successfully authenticated attempts to get statistical energy data on all registered Alpha ESS systems - will return None if there are issues retrieving data from the Alpha ESS API.
 
+setbatterycharge(serial, enabled, cp1start, cp1end, cp2start, cp2end, chargestopsoc) - having successfully authenticated set battery grid charging settings for the SN.
+
+setbatterydischarge(serial, enabled, dp1start, dp1end, dp2start, dp2end, dischargecutoffsoc) - having successfully authenticated set battery discharge settings for the SN.

--- a/apitest.py
+++ b/apitest.py
@@ -1,9 +1,6 @@
-from distutils.log import debug
 import logging
 import asyncio
-from urllib import response
 import aiohttp
-from os import stat
 import sys
 import datetime
 
@@ -13,8 +10,7 @@ from alphaess.alphaess import alphaess
 
 username = input("username: ")
 password = input("password: ")
-
-
+serial = input("serial: ")
 
 logger = logging.getLogger('')
 logger.setLevel(logging.DEBUG)
@@ -46,6 +42,9 @@ async def main():
                 charge = data[0]["system_statistics"]["ECharge"]        
                 print(f"charge: {charge[index]}")
 
+            await client.setbatterycharge(serial, False, "00:00", "00:00", "00:00", "00:00", 100)
+            await client.setbatterydischarge(serial, False, "00:00", "00:00", "00:00", "00:00", 1)
+
     except aiohttp.ClientResponseError as e:
         if e.status == 401:
             logger.error("Authentication Error")
@@ -53,7 +52,5 @@ async def main():
             logger.error(e)
     except Exception as e:
         logger.error(e)
-
-
 
 asyncio.run(main())

--- a/apitest.py
+++ b/apitest.py
@@ -10,7 +10,6 @@ from alphaess.alphaess import alphaess
 
 username = input("username: ")
 password = input("password: ")
-serial = input("serial: ")
 
 logger = logging.getLogger('')
 logger.setLevel(logging.DEBUG)
@@ -33,6 +32,10 @@ async def main():
         if authenticated:
             data = await client.getdata()
             print(f"all data: {data}")
+            if data:
+                if "sys_sn" in data[0]:
+                    serial = data[0]['sys_sn']
+            print(f"serial: {serial}")
 
             index = int(datetime.date.today().strftime("%d")) - 1
             if "EDischarge" in data:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="alphaess",
-    version="0.0.6",
+    version="0.0.7",
     author="Charles Gillanders",
     author_email="charles@charlesgillanders.com",
     description="A python library to retrieve energy statistics from your Alpha ESS inverter by polling the Alpha ESS web API.",


### PR DESCRIPTION
Hi Charles,
I have added a postman collection to see the returned data from the api calls, for the settings it doesn't appear to return an array, but there is an endpoint GetCustomUseESSList (similar to GetCustomMenuESSList) which returns an array, and then the subsequent call to GetCustomUseESSSetting uses system_id from the prior. I don't know why this api would use the system_id and not the sys_sn as in others, but it does.
To get around this there is an internal system_id_for_sn to make the conversion for the settings call given the sys_sn.
I hope this will help to make it work for all cases with people with multiple systems.
Renamed & refactored a couple internal methods to differentiate between the generic post & get data