### PR TITLE
Separate data functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,22 @@ Currently this package uses an API that I reverse engineered the API from the Al
 
 # Methods
 
-There are four public methods in this module
+`authenticate(username, password)` - attempts to authenticate to the ALpha ESS API with a username and password combination, returns True or False depending on successful authentication or not
 
-authenticate(username, password) - attempts to authenticate to the ALpha ESS API with a username and password combination, returns True or False depending on successful authentication or not
+The remaining methods require authentication. Will throw Exceptions on failure.
 
-getdata() - having successfully authenticated attempts to get statistical energy data on all registered Alpha ESS systems - will return None if there are issues retrieving data from the Alpha ESS API.
+`getunits()` - get a list of ESS units in account
 
-setbatterycharge(serial, enabled, cp1start, cp1end, cp2start, cp2end, chargestopsoc) - having successfully authenticated set battery grid charging settings for the SN.
+`getdailystatistics(serial)` - retrieves daily statistics for supplied ESS serial number
 
-setbatterydischarge(serial, enabled, dp1start, dp1end, dp2start, dp2end, dischargecutoffsoc) - having successfully authenticated set battery discharge settings for the SN.
+`getsystemstatistics(serial)` - retrieves system statistics for supplied ESS serial number
+
+`getpowerdata(serial)` - retrieves current power statistics (PV output, load, grid import/export etc.) for supplied ESS serial number
+
+`getsettings(serial)` - retrieves supplied ESS serial number settings
+
+`getdata()` - iterate through all available Alpha ESS systems and get all statistical energy data - will return None if there are issues retrieving data from the Alpha ESS API.
+
+`setbatterycharge(serial, enabled, cp1start, cp1end, cp2start, cp2end, chargestopsoc)` - set battery grid charging settings for the SN.
+
+`setbatterydischarge(serial, enabled, dp1start, dp1end, dp2start, dp2end, dischargecutoffsoc)` - set battery discharge settings for the SN.

--- a/alphaess/alphaess.py
+++ b/alphaess/alphaess.py
@@ -25,6 +25,7 @@ class alphaess:
         self.expiresin = None
         self.tokencreatetime = None
         self.refreshtoken = None
+        self.esslist = None
 
     def __headers(self):
         timestamp = str(int(time.time()))
@@ -142,13 +143,61 @@ class alphaess:
                 return await self.__refresh()
         return await self.authenticate(self.username, self.password)
 
+    async def getunits(self) -> Optional(list):
+        """Retrieve a list of ESS units in account"""
+
+        try:
+            if self.esslist is None:
+                logger.debug("Getting ESS List")
+                self.esslist = await self.__get_data("Account/GetCustomMenuESSList")
+            return self.esslist
+        except Exception as e:
+            logger.error(e)
+            raise
+
+    async def getdailystatistics(self, serial) -> Optional(list):
+        """Retrieve daily statistics for supplied unit serial"""
+
+        try:
+            return await self.__daily_statistics(serial)
+        except Exception as e:
+            logger.error(e)
+            raise
+
+    async def getsystemstatistics(self, serial) -> Optional(list):
+        """Retrieve system statistics for supplied unit serial"""
+
+        try:
+            return await self.__system_statistics(serial)
+        except Exception as e:
+            logger.error(e)
+            raise
+
+    async def getpowerdata(self, serial) -> Optional(list):
+        """Retrieve power data for supplied unit serial"""
+
+        try:
+            return await self.__powerdata(serial)
+        except Exception as e:
+            logger.error(e)
+            raise
+
+    async def getsettings(self, serial) -> Optional(list):
+        """Retrieve settings for supplied unit serial"""
+
+        try:
+            system = await self.__system_id_for_sn(serial)
+            return await self.__settings(system)
+        except Exception as e:
+            logger.error(e)
+            raise
+
     async def getdata(self) -> Optional(list):
         """Retrieve ESS list by serial number from Alpha ESS"""
 
         try:
-            alldata = []
-            units = await self.__get_data("Account/GetCustomMenuESSList")
-            logger.debug(alldata)
+            alldata = []           
+            units = await self.getunits()
 
             for unit in units:
                 if "sys_sn" in unit:

--- a/individual_function_test.py
+++ b/individual_function_test.py
@@ -1,0 +1,69 @@
+import logging
+import asyncio
+import aiohttp
+import sys
+import datetime
+
+from alphaess.alphaess import alphaess
+
+if len(sys.argv) != 3:
+    username = input("username: ")
+    password = input("password: ")
+else:
+    username = sys.argv[1]
+    password = sys.argv[2]
+
+logger = logging.getLogger('')
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter('[%(asctime)s] %(levelname)s [%(filename)s.%(funcName)s:%(lineno)d] %(message)s', datefmt='%a, %d %b %Y %H:%M:%S')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+async def main():
+
+    logger.debug("instantiating Alpha ESS Client")
+
+    client: alphaess = alphaess()
+
+    logger.debug("Checking authentication")
+    try:
+        authenticated = await client.authenticate(username, password)
+    
+        if authenticated:
+            # Get a list of available ESS units
+            essunits = await client.getunits()
+
+            print(f"units: {essunits}")
+
+            # Explicitly extract serial numbers
+            myunits = []
+            for unit in essunits:
+                if "sys_sn" in unit:
+                    myunits.append(unit["sys_sn"])
+
+            print(f"my unit serial numbers: {myunits}")
+
+            # Get stats for each
+            for serial in myunits:
+                dailystatistics = await client.getdailystatistics(serial)
+                print(f"daily statistics for {serial}: {dailystatistics}")
+
+                systemstatistics = await client.getsystemstatistics(serial)
+                print(f"system statistics for {serial}: {systemstatistics}")
+
+                powerdata = await client.getpowerdata(serial)
+                print(f"power data for {serial}: {powerdata}")
+
+                settings = await client.getsettings(serial)
+                print(f"settings for {serial}: {settings}")
+            
+    except aiohttp.ClientResponseError as e:
+        if e.status == 401:
+            logger.error("Authentication Error")
+        else:
+            logger.error(e)
+    except Exception as e:
+        logger.error(e)
+
+asyncio.run(main())


### PR DESCRIPTION
#9 

Reduce HTTP calls to AlphaCloud API.

Adds function to get list of available ESS units (and caches result):

`getunits()`

Adds separate functions to retrieve specific data for specific units:

`getdailystatistics(serial)` 
`getsystemstatistics(serial)`
`getpowerdata(serial)`
`getsettings(serial)`

Retains backward compatibility